### PR TITLE
#14 Preserve cursor position across edits

### DIFF
--- a/projects/java-project/.idea/workspace.xml
+++ b/projects/java-project/.idea/workspace.xml
@@ -74,6 +74,8 @@
       <sortByType />
     </navigator>
     <panes>
+      <pane id="Scope" />
+      <pane id="PackagesPane" />
       <pane id="ProjectPane">
         <subPane>
           <PATH>
@@ -84,8 +86,6 @@
           </PATH>
         </subPane>
       </pane>
-      <pane id="PackagesPane" />
-      <pane id="Scope" />
     </panes>
   </component>
   <component name="PropertiesComponent">
@@ -211,9 +211,9 @@
       <window_info id="Message" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
       <window_info id="Find" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
       <window_info id="Debug" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.4" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
-      <window_info id="Run" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
-      <window_info id="Inspection" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.4" sideWeight="0.5" order="5" side_tool="false" content_ui="tabs" />
       <window_info id="Hierarchy" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.25" sideWeight="0.5" order="2" side_tool="false" content_ui="combo" />
+      <window_info id="Inspection" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.4" sideWeight="0.5" order="5" side_tool="false" content_ui="tabs" />
+      <window_info id="Run" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
     </layout>
   </component>
   <component name="Vcs.Log.UiProperties">
@@ -248,6 +248,14 @@
     <option name="FILTER_TARGETS" value="false" />
   </component>
   <component name="editorHistoryManager">
+    <entry file="file://$PROJECT_DIR$/src/org/intellivim/javaproject/Dummy.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0" vertical-offset="120" max-vertical-offset="435">
+          <caret line="8" column="13" selection-start-line="8" selection-start-column="13" selection-end-line="8" selection-end-column="13" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
     <entry file="file://$PROJECT_DIR$/src/org/intellivim/javaproject/Dummy.java">
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0" vertical-offset="120" max-vertical-offset="435">

--- a/projects/java-project/.idea/workspace.xml
+++ b/projects/java-project/.idea/workspace.xml
@@ -43,8 +43,8 @@
     </FindUsagesManager>
   </component>
   <component name="ProjectFrameBounds">
-    <option name="x" value="728" />
-    <option name="y" value="223" />
+    <option name="x" value="280" />
+    <option name="y" value="23" />
     <option name="width" value="1400" />
     <option name="height" value="1000" />
   </component>
@@ -74,8 +74,6 @@
       <sortByType />
     </navigator>
     <panes>
-      <pane id="PackagesPane" />
-      <pane id="Scope" />
       <pane id="ProjectPane">
         <subPane>
           <PATH>
@@ -84,32 +82,10 @@
               <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
             </PATH_ELEMENT>
           </PATH>
-          <PATH>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="java-project" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="java-project" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-          </PATH>
-          <PATH>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="java-project" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="java-project" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="src" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-          </PATH>
         </subPane>
       </pane>
+      <pane id="PackagesPane" />
+      <pane id="Scope" />
     </panes>
   </component>
   <component name="PropertiesComponent">
@@ -212,7 +188,7 @@
     <servers />
   </component>
   <component name="ToolWindowManager">
-    <frame x="728" y="223" width="1400" height="1000" extended-state="0" />
+    <frame x="280" y="23" width="1400" height="1000" extended-state="0" />
     <editor active="false" />
     <layout>
       <window_info id="Palette&#9;" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
@@ -272,6 +248,30 @@
     <option name="FILTER_TARGETS" value="false" />
   </component>
   <component name="editorHistoryManager">
+    <entry file="file://$PROJECT_DIR$/src/org/intellivim/javaproject/Dummy.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0" vertical-offset="120" max-vertical-offset="435">
+          <caret line="8" column="13" selection-start-line="8" selection-start-column="13" selection-end-line="8" selection-end-column="13" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/org/intellivim/javaproject/Dummy.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="435">
+          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/org/intellivim/javaproject/Dummy.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0" vertical-offset="120" max-vertical-offset="435">
+          <caret line="8" column="13" selection-start-line="8" selection-start-column="13" selection-end-line="8" selection-end-column="13" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
     <entry file="file://$PROJECT_DIR$/src/org/intellivim/javaproject/Dummy.java">
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="435">

--- a/projects/runnable-project/.idea/workspace.xml
+++ b/projects/runnable-project/.idea/workspace.xml
@@ -31,7 +31,7 @@
             <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="903">
               <caret line="0" column="13" selection-start-line="0" selection-start-column="13" selection-end-line="0" selection-end-column="13" />
               <folding>
-                <marker date="1426532933000" expanded="true" signature="114:214" placeholder="{...}" />
+                <marker date="1426599273000" expanded="true" signature="134:259" placeholder="{...}" />
               </folding>
             </state>
           </provider>
@@ -249,9 +249,9 @@
       <window_info id="Message" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
       <window_info id="Find" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
       <window_info id="Debug" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.4" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
-      <window_info id="Hierarchy" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.25" sideWeight="0.5" order="2" side_tool="false" content_ui="combo" />
-      <window_info id="Inspection" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.4" sideWeight="0.5" order="5" side_tool="false" content_ui="tabs" />
       <window_info id="Run" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
+      <window_info id="Inspection" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.4" sideWeight="0.5" order="5" side_tool="false" content_ui="tabs" />
+      <window_info id="Hierarchy" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.25" sideWeight="0.5" order="2" side_tool="false" content_ui="combo" />
     </layout>
   </component>
   <component name="Vcs.Log.UiProperties">
@@ -287,11 +287,29 @@
   <component name="editorHistoryManager">
     <entry file="file://$PROJECT_DIR$/src/org/intellivim/runnable/RunnableMain.java">
       <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="255">
+          <caret line="0" column="13" selection-start-line="0" selection-start-column="13" selection-end-line="0" selection-end-column="13" />
+          <folding>
+            <marker date="1426599273000" expanded="true" signature="134:259" placeholder="{...}" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/org/intellivim/runnable/RunnableMain.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="255">
+          <caret line="0" column="13" selection-start-line="0" selection-start-column="13" selection-end-line="0" selection-end-column="13" />
+          <folding>
+            <marker date="1426599273000" expanded="true" signature="134:259" placeholder="{...}" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/org/intellivim/runnable/RunnableMain.java">
+      <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="210">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding>
-            <marker date="1426532933000" expanded="true" signature="114:214" placeholder="{...}" />
-          </folding>
+          <folding />
         </state>
       </provider>
     </entry>
@@ -396,7 +414,7 @@
         <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="903">
           <caret line="0" column="13" selection-start-line="0" selection-start-column="13" selection-end-line="0" selection-end-column="13" />
           <folding>
-            <marker date="1426532933000" expanded="true" signature="114:214" placeholder="{...}" />
+            <marker date="1426599273000" expanded="true" signature="134:259" placeholder="{...}" />
           </folding>
         </state>
       </provider>

--- a/projects/runnable-project/.idea/workspace.xml
+++ b/projects/runnable-project/.idea/workspace.xml
@@ -31,7 +31,7 @@
             <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="903">
               <caret line="0" column="13" selection-start-line="0" selection-start-column="13" selection-end-line="0" selection-end-column="13" />
               <folding>
-                <marker date="1426599273000" expanded="true" signature="134:259" placeholder="{...}" />
+                <marker date="1426600022000" expanded="true" signature="105:230" placeholder="{...}" />
               </folding>
             </state>
           </provider>
@@ -249,9 +249,9 @@
       <window_info id="Message" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
       <window_info id="Find" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
       <window_info id="Debug" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.4" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
-      <window_info id="Run" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
-      <window_info id="Inspection" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.4" sideWeight="0.5" order="5" side_tool="false" content_ui="tabs" />
       <window_info id="Hierarchy" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.25" sideWeight="0.5" order="2" side_tool="false" content_ui="combo" />
+      <window_info id="Inspection" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.4" sideWeight="0.5" order="5" side_tool="false" content_ui="tabs" />
+      <window_info id="Run" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
     </layout>
   </component>
   <component name="Vcs.Log.UiProperties">
@@ -287,10 +287,10 @@
   <component name="editorHistoryManager">
     <entry file="file://$PROJECT_DIR$/src/org/intellivim/runnable/RunnableMain.java">
       <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="255">
-          <caret line="0" column="13" selection-start-line="0" selection-start-column="13" selection-end-line="0" selection-end-column="13" />
+        <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="225">
+          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
           <folding>
-            <marker date="1426599273000" expanded="true" signature="134:259" placeholder="{...}" />
+            <marker date="1426600022000" expanded="true" signature="105:230" placeholder="{...}" />
           </folding>
         </state>
       </provider>
@@ -300,7 +300,17 @@
         <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="255">
           <caret line="0" column="13" selection-start-line="0" selection-start-column="13" selection-end-line="0" selection-end-column="13" />
           <folding>
-            <marker date="1426599273000" expanded="true" signature="134:259" placeholder="{...}" />
+            <marker date="1426600022000" expanded="true" signature="105:230" placeholder="{...}" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/org/intellivim/runnable/RunnableMain.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="255">
+          <caret line="0" column="13" selection-start-line="0" selection-start-column="13" selection-end-line="0" selection-end-column="13" />
+          <folding>
+            <marker date="1426600022000" expanded="true" signature="105:230" placeholder="{...}" />
           </folding>
         </state>
       </provider>
@@ -309,7 +319,9 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="210">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
+          <folding>
+            <marker date="1426600022000" expanded="true" signature="105:230" placeholder="{...}" />
+          </folding>
         </state>
       </provider>
     </entry>
@@ -317,7 +329,9 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="270">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
+          <folding>
+            <marker date="1426600022000" expanded="true" signature="105:230" placeholder="{...}" />
+          </folding>
         </state>
       </provider>
     </entry>
@@ -325,7 +339,9 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="255">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
+          <folding>
+            <marker date="1426600022000" expanded="true" signature="105:230" placeholder="{...}" />
+          </folding>
         </state>
       </provider>
     </entry>
@@ -333,7 +349,9 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="225">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
+          <folding>
+            <marker date="1426600022000" expanded="true" signature="105:230" placeholder="{...}" />
+          </folding>
         </state>
       </provider>
     </entry>
@@ -341,7 +359,9 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="255">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
+          <folding>
+            <marker date="1426600022000" expanded="true" signature="105:230" placeholder="{...}" />
+          </folding>
         </state>
       </provider>
     </entry>
@@ -349,7 +369,9 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="225">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
+          <folding>
+            <marker date="1426600022000" expanded="true" signature="105:230" placeholder="{...}" />
+          </folding>
         </state>
       </provider>
     </entry>
@@ -357,7 +379,9 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="225">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
+          <folding>
+            <marker date="1426600022000" expanded="true" signature="105:230" placeholder="{...}" />
+          </folding>
         </state>
       </provider>
     </entry>
@@ -365,7 +389,9 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="210">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
+          <folding>
+            <marker date="1426600022000" expanded="true" signature="105:230" placeholder="{...}" />
+          </folding>
         </state>
       </provider>
     </entry>
@@ -373,7 +399,9 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="210">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
+          <folding>
+            <marker date="1426600022000" expanded="true" signature="105:230" placeholder="{...}" />
+          </folding>
         </state>
       </provider>
     </entry>
@@ -381,7 +409,9 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="210">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
+          <folding>
+            <marker date="1426600022000" expanded="true" signature="105:230" placeholder="{...}" />
+          </folding>
         </state>
       </provider>
     </entry>
@@ -389,7 +419,9 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="210">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
+          <folding>
+            <marker date="1426600022000" expanded="true" signature="105:230" placeholder="{...}" />
+          </folding>
         </state>
       </provider>
     </entry>
@@ -397,7 +429,9 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="210">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
+          <folding>
+            <marker date="1426600022000" expanded="true" signature="105:230" placeholder="{...}" />
+          </folding>
         </state>
       </provider>
     </entry>
@@ -405,7 +439,9 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0" vertical-offset="30" max-vertical-offset="210">
           <caret line="2" column="13" selection-start-line="2" selection-start-column="13" selection-end-line="2" selection-end-column="13" />
-          <folding />
+          <folding>
+            <marker date="1426600022000" expanded="true" signature="105:230" placeholder="{...}" />
+          </folding>
         </state>
       </provider>
     </entry>
@@ -414,7 +450,7 @@
         <state vertical-scroll-proportion="0.0" vertical-offset="0" max-vertical-offset="903">
           <caret line="0" column="13" selection-start-line="0" selection-start-column="13" selection-end-line="0" selection-end-column="13" />
           <folding>
-            <marker date="1426599273000" expanded="true" signature="134:259" placeholder="{...}" />
+            <marker date="1426600022000" expanded="true" signature="105:230" placeholder="{...}" />
           </folding>
         </state>
       </provider>

--- a/src/main/java/IVCore.java
+++ b/src/main/java/IVCore.java
@@ -86,6 +86,7 @@ public class IVCore implements ApplicationComponent {
             final Result result = collectResult(future);
             final String json = gson.toJson(result);
             final int code = result.isSuccess() ? 200 : 400;
+            System.out.println(json);
 
             // send headers
             httpExchange.sendResponseHeaders(code, json.length());

--- a/src/main/java/org/intellivim/SimpleResult.java
+++ b/src/main/java/org/intellivim/SimpleResult.java
@@ -27,10 +27,22 @@ public class SimpleResult implements Result {
         return (T) result;
     }
 
-    public SimpleResult withOffsetFrom(RangeMarker marker) {
-        final int editorOffset = marker.getStartOffset();
-        if (editorOffset > 0) {
-            newOffset = editorOffset;
+    /**
+     * Some commands may edit the text, and we would like to
+     *  preserve the cursor position across such edits.
+     *  You can use {@see VimEditor#createRangeMarker()} before
+     *  performing the edit and pass it here after, then
+     *  utilize the newOffset field of the result
+     *
+     * @return This object again, Builder-style
+     */
+    public SimpleResult withOffsetFrom(final RangeMarker marker) {
+        if (marker != null) {
+            final int editorOffset = marker.getStartOffset();
+            System.out.println("marker=" + editorOffset);
+            if (editorOffset > 0) {
+                newOffset = editorOffset;
+            }
         }
         return this;
     }

--- a/src/main/java/org/intellivim/SimpleResult.java
+++ b/src/main/java/org/intellivim/SimpleResult.java
@@ -1,5 +1,7 @@
 package org.intellivim;
 
+import com.intellij.openapi.editor.RangeMarker;
+
 /**
  * Convenient implementation of Result
  * @author dhleong
@@ -8,15 +10,29 @@ public class SimpleResult implements Result {
     public final String error;
     public final Object result;
 
+    private int newOffset;
+
     SimpleResult(String error, Object result) {
         this.error = error;
         this.result = result;
+    }
+
+    public int getNewOffset() {
+        return newOffset;
     }
 
     /** Convenience method to avoid casting when you're sure of what it is */
     @SuppressWarnings("unchecked")
     public <T> T getResult() {
         return (T) result;
+    }
+
+    public SimpleResult withOffsetFrom(RangeMarker marker) {
+        final int editorOffset = marker.getStartOffset();
+        if (editorOffset > 0) {
+            newOffset = editorOffset;
+        }
+        return this;
     }
 
     @Override

--- a/src/main/java/org/intellivim/core/command/problems/FixProblemCommand.java
+++ b/src/main/java/org/intellivim/core/command/problems/FixProblemCommand.java
@@ -1,5 +1,6 @@
 package org.intellivim.core.command.problems;
 
+import com.intellij.openapi.editor.RangeMarker;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiFile;
 import org.intellivim.Command;
@@ -26,6 +27,7 @@ public class FixProblemCommand extends ProjectCommand {
     @Required @Inject PsiFile file;
     @Required String fixId;
 
+    /* optional */int offset;
     /* optional */String arg;
 
     public FixProblemCommand(Project project, String filePath, String fixId) {
@@ -42,12 +44,13 @@ public class FixProblemCommand extends ProjectCommand {
     public Result execute() {
 
         final QuickFixDescriptor fix = selectFix();
-        final VimEditor editor = new VimEditor(project, file, 0);
+        final VimEditor editor = new VimEditor(project, file, offset);
+        RangeMarker marker = editor.createRangeMarker();
 
         try {
             return SimpleResult.success(
                     fix.execute(project, editor, file, arg)
-            );
+            ).withOffsetFrom(marker);
         } catch (QuickFixException e) {
             return SimpleResult.error(e);
         }

--- a/src/main/java/org/intellivim/core/model/VimCaretModel.java
+++ b/src/main/java/org/intellivim/core/model/VimCaretModel.java
@@ -1,10 +1,15 @@
 package org.intellivim.core.model;
 
-import com.intellij.openapi.editor.*;
+import com.intellij.openapi.editor.Caret;
+import com.intellij.openapi.editor.CaretAction;
+import com.intellij.openapi.editor.CaretModel;
+import com.intellij.openapi.editor.CaretState;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.LogicalPosition;
+import com.intellij.openapi.editor.VisualPosition;
 import com.intellij.openapi.editor.event.CaretListener;
-import com.intellij.openapi.editor.impl.CaretImpl;
 import com.intellij.openapi.editor.markup.TextAttributes;
-import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.UserDataHolderBase;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -19,22 +24,18 @@ public class VimCaretModel implements CaretModel {
 
     private VimEditor editor;
     private Document doc;
-    private int offset;
     private LogicalPosition logicalPosition;
 
     public VimCaretModel(VimEditor editor, Document doc, int offset) {
         this.editor = editor;
         this.doc = doc;
-        this.offset = offset;
 
-        int row = doc.getLineNumber(offset);
-        int col = offset - doc.getLineStartOffset(row);
-        moveToLogicalPosition(new LogicalPosition(row, col));
+        moveToOffset(offset);
     }
 
     @Override
     public void moveCaretRelatively(int columnShift, int lineShift, boolean withSelection, boolean blockSelection, boolean scrollToCaret) {
-
+        System.out.println(" *\n * MOVE RELATIVELY\n *");
     }
 
     @Override
@@ -44,12 +45,14 @@ public class VimCaretModel implements CaretModel {
 
     @Override
     public void moveToVisualPosition(@NotNull VisualPosition pos) {
-
+        System.out.println(" *\n * MOVE VISUAL\n *");
     }
 
     @Override
     public void moveToOffset(int offset) {
-        this.offset = offset;
+        final int line = doc.getLineNumber(offset);
+        final int col = offset - doc.getLineStartOffset(line);
+        moveToLogicalPosition(new LogicalPosition(line, col));
     }
 
     @Override
@@ -77,7 +80,7 @@ public class VimCaretModel implements CaretModel {
 
     @Override
     public int getOffset() {
-//        System.out.println("  >> VimCaretModel.getOffset");
+//        System.out.println("  >> " + this + ".getOffset ->" + logicalPosition);
         return doc.getLineStartOffset(logicalPosition.line) + logicalPosition.column;
     }
 

--- a/src/main/java/org/intellivim/core/model/VimDocument.java
+++ b/src/main/java/org/intellivim/core/model/VimDocument.java
@@ -1,5 +1,6 @@
 package org.intellivim.core.model;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.ex.DocumentEx;
 import com.intellij.openapi.editor.impl.DocumentImpl;
@@ -16,6 +17,15 @@ import org.jetbrains.annotations.NotNull;
 public class VimDocument extends DocumentImpl implements DocumentEx {
     private PsiFile psiFile;
     private boolean forceEventsHandling;
+
+    /** Testing only */
+    public VimDocument(@NotNull CharSequence chars) {
+        this(null, chars);
+
+        if (!ApplicationManager.getApplication().isUnitTestMode()) {
+            throw new IllegalStateException("This constructor is ONLY for testing");
+        }
+    }
 
     VimDocument(PsiFile psiFile) {
         this(psiFile, psiFile.getViewProvider().getContents());

--- a/vim/autoload/intellivim/core.vim
+++ b/vim/autoload/intellivim/core.vim
@@ -71,6 +71,11 @@ endfunction " }}}
 function! intellivim#core#ReloadFile(...) " {{{
     " Update the contents/state of a file after
     "  we (think) it has been changed externally
+    " Optional Argument:
+    "  - "result" A result from executing a comand.
+    "             If provided, we will attempt to
+    "             update the cursor position to match
+    "             the newOffset parameter, if provided.
 
     let result = a:0 ? a:1 : {}
 

--- a/vim/autoload/intellivim/core.vim
+++ b/vim/autoload/intellivim/core.vim
@@ -68,17 +68,30 @@ function! intellivim#core#Setup() " {{{
 
 endfunction " }}}
 
-function! intellivim#core#ReloadFile() " {{{
+function! intellivim#core#ReloadFile(...) " {{{
     " Update the contents/state of a file after
     "  we (think) it has been changed externally
+
+    let result = a:0 ? a:1 : {}
 
     " reload the file
     edit!
 
-    " TODO somehow preserve cursor position?
-
     " refresh problems
     call intellivim#core#Update()
+
+    " if they provided a useful newOffset, use it!
+    if has_key(result, 'newOffset')
+        let newOffset = result.newOffset
+        if newOffset > 0
+            " NB add 1 to col because offset is from zero,
+            "  and another 1 because col is 1-indexed
+            let line = byte2line(newOffset)
+            let col = newOffset - line2byte(line) + 2
+            call cursor(line, col)
+        endif
+    endif
+
 endfunction " }}}
 
 function! intellivim#core#Update() " {{{

--- a/vim/autoload/intellivim/core/problems.vim
+++ b/vim/autoload/intellivim/core/problems.vim
@@ -118,6 +118,7 @@ function s:OnPerformFix(oldWinr, fixId, ...) " {{{
     exe a:oldWinr . 'winc w'
 
     let command = intellivim#NewCommand("quickfix")
+    let command.offset = intellivim#GetOffset()
     let command.fixId = a:fixId
 
     if a:0
@@ -130,7 +131,7 @@ function s:OnPerformFix(oldWinr, fixId, ...) " {{{
         return
     endif
 
-    call intellivim#core#ReloadFile()
+    call intellivim#core#ReloadFile(result)
 
 endfunction " }}}
 

--- a/vim/autoload/intellivim/java.vim
+++ b/vim/autoload/intellivim/java.vim
@@ -15,13 +15,14 @@ endfunction " }}}
 function! intellivim#java#OptimizeImports() " {{{
 
     let command = intellivim#NewCommand("java_import_optimize")
+    let command.offset = intellivim#GetOffset()
     let result = intellivim#client#Execute(command)
 
     if intellivim#ShowErrorResult(result)
         return
     endif
 
-    call intellivim#core#ReloadFile()
+    call intellivim#core#ReloadFile(result)
 
     if !has_key(result, 'result') || !type(result.result) == type([])
         " all unambiguous


### PR DESCRIPTION
We specifically handle `:FixProblem` and `:JavaOptimizeImports` (I think those are the only ones that need it right now) but it is straightforward to add to future commands:

1. Add `let command.offset = intellivim#GetOffset()` to the command initialization
2. Pass the `result` to `intellivim#core#ReloadFile(result)`
3. Add the `int offset` field to the command implementation, and pass it to any constructed `VimEditor`s
4. Use `VimEditor#createRangeMarker()` to record the initial position
5. Decorate your `SimpleResult` using `withOffsetFrom(marker)`

Voila!