### PR TITLE
Use existing document when possible

### DIFF
--- a/src/main/java/org/intellivim/core/command/problems/Problems.java
+++ b/src/main/java/org/intellivim/core/command/problems/Problems.java
@@ -13,7 +13,6 @@ import com.intellij.openapi.util.Condition;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.impl.cache.impl.todo.TodoIndex;
 import com.intellij.psi.stubs.StubUpdatingIndex;
-import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.indexing.FileBasedIndex;
 import org.intellivim.core.model.VimEditor;
 

--- a/src/main/java/org/intellivim/core/model/VimDocument.java
+++ b/src/main/java/org/intellivim/core/model/VimDocument.java
@@ -73,12 +73,15 @@ public class VimDocument extends DocumentImpl implements DocumentEx {
         return "VimDocument: " + super.toString();
     }
 
-    public static VimDocument getInstance(@NotNull PsiFile originalFile) {
+    public static DocumentEx getInstance(@NotNull PsiFile originalFile) {
         VirtualFile file = originalFile.getVirtualFile();
         final Document doc = FileDocumentManager.getInstance()
                 .getCachedDocument(file);
-        if (doc instanceof VimDocument) {
-            return (VimDocument) doc;
+//        if (doc instanceof VimDocument) {
+//            return (VimDocument) doc;
+//        }
+        if (doc instanceof DocumentEx) {
+            return (DocumentEx) doc;
         }
 
         // create and cache

--- a/src/main/java/org/intellivim/core/model/VimEditor.java
+++ b/src/main/java/org/intellivim/core/model/VimEditor.java
@@ -75,7 +75,7 @@ public class VimEditor extends UserDataHolderBase implements EditorEx {
     }
 
     /** For TESTING only */
-    public VimEditor(VimDocument doc, int offset) {
+    public VimEditor(DocumentEx doc, int offset) {
         this(null, null, doc, offset);
 
         if (!ApplicationManager.getApplication().isUnitTestMode()) {
@@ -83,7 +83,7 @@ public class VimEditor extends UserDataHolderBase implements EditorEx {
         }
     }
 
-    private VimEditor(Project project, PsiFile originalFile, VimDocument document, int offset) {
+    private VimEditor(Project project, PsiFile originalFile, DocumentEx document, int offset) {
         this.project = project;
         this.originalFile = originalFile;
         doc = document;

--- a/src/main/java/org/intellivim/core/util/IntelliVimUtil.java
+++ b/src/main/java/org/intellivim/core/util/IntelliVimUtil.java
@@ -3,6 +3,8 @@ package org.intellivim.core.util;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.impl.ApplicationImpl;
 import com.intellij.openapi.command.CommandProcessor;
+import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Computable;
 import com.intellij.util.ui.UIUtil;
 
@@ -97,6 +99,20 @@ public class IntelliVimUtil {
             @Override
             public void run() {
                 ApplicationManager.getApplication().runWriteAction(runnable);
+            }
+        };
+    }
+
+    /**
+     * @return A new Runnable that wraps execution of the given
+     *  Runnable to be "run when smart"
+     */
+    public static Runnable whenSmart(final Project project, final Runnable runWhenSmart) {
+        return new Runnable() {
+            @Override
+            public void run() {
+                final DumbService dumbService = DumbService.getInstance(project);
+                dumbService.runWhenSmart(runWhenSmart);
             }
         };
     }

--- a/src/main/java/org/intellivim/core/util/ProjectUtil.java
+++ b/src/main/java/org/intellivim/core/util/ProjectUtil.java
@@ -1,5 +1,7 @@
 package org.intellivim.core.util;
 
+import com.intellij.openapi.editor.ex.DocumentEx;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ex.ProjectManagerEx;
 import com.intellij.openapi.project.impl.ProjectManagerImpl;
@@ -11,6 +13,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.WindowManager;
 import com.intellij.openapi.wm.impl.IdeFrameImpl;
 import com.intellij.openapi.wm.impl.WindowManagerImpl;
+import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import com.intellij.psi.impl.PsiManagerImpl;
@@ -26,7 +29,7 @@ import org.jdom.JDOMException;
 import org.jetbrains.annotations.NotNull;
 import org.picocontainer.MutablePicoContainer;
 
-import javax.swing.*;
+import javax.swing.JFrame;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -133,6 +136,12 @@ public class ProjectUtil {
                         ((PsiManagerImpl) mgr).getFileManager().cleanupForNextTest();
                         final PsiFile file = mgr.findFile(virtual);
                         mgr.reloadFromDisk(file);
+
+                        // ensure the doc is up to date as well
+                        final DocumentEx doc = VimDocument.getInstance(file);
+                        FileDocumentManager.getInstance().reloadFromDisk(doc);
+                        PsiDocumentManager.getInstance(project).commitDocument(doc);
+
                         PsiUtilCore.ensureValid(file);
                         return file;
                     }

--- a/src/main/java/org/intellivim/java/command/OptimizeImportsCommand.java
+++ b/src/main/java/org/intellivim/java/command/OptimizeImportsCommand.java
@@ -74,37 +74,23 @@ public class OptimizeImportsCommand extends ProjectCommand {
 
         final List<ImportsQuickFixDescriptor> ambiguous =
                 new ArrayList<ImportsQuickFixDescriptor>();
-        IntelliVimUtil.runInUnitTestMode(new Runnable() {
+        final boolean old = CodeInsightSettings.getInstance().ADD_UNAMBIGIOUS_IMPORTS_ON_THE_FLY;
+        CodeInsightSettings.getInstance().ADD_UNAMBIGIOUS_IMPORTS_ON_THE_FLY = true;
 
-            @Override
-            public void run() {
-                final boolean old = CodeInsightSettings.getInstance().ADD_UNAMBIGIOUS_IMPORTS_ON_THE_FLY;
-                CodeInsightSettings.getInstance().ADD_UNAMBIGIOUS_IMPORTS_ON_THE_FLY = true;
-
-                for (final ImportsQuickFixDescriptor desc : findImportProblemFixes()) {
-                    try {
-//                        System.out.println("Executing " + desc.getDescription());
-//                        if (!psiFile.textMatches(editor.getDocument().getCharsSequence())) {
-//                            System.out.println("Using " + psiFile.getText());
-//                            System.out.println("Vs: " + editor.getDocument().getCharsSequence());
-//                        }
-                        Object result = desc.execute(project, editor, psiFile, null);
-                        if (null != result) {
-                            // it was ambiguous
-                            ambiguous.add(desc);
-                        }
-//                        System.out.println("Executed: " + desc.getDescription());
-
-                    } catch (QuickFixException e) {
-                        // don't care
-                    }
+        for (final ImportsQuickFixDescriptor desc : findImportProblemFixes()) {
+            try {
+                final Object result = desc.execute(project, editor, psiFile, null);
+                if (null != result) {
+                    // it was ambiguous
+                    ambiguous.add(desc);
                 }
 
-                CodeInsightSettings.getInstance().ADD_UNAMBIGIOUS_IMPORTS_ON_THE_FLY = old;
-
-                FileUtil.commitChanges(editor);
+            } catch (QuickFixException e) {
+                // don't care
             }
-        });
+        }
+
+        CodeInsightSettings.getInstance().ADD_UNAMBIGIOUS_IMPORTS_ON_THE_FLY = old;
 
         // prepare again
         prepare();
@@ -139,7 +125,7 @@ public class OptimizeImportsCommand extends ProjectCommand {
         }
     }
 
-    private Iterable<ImportsQuickFixDescriptor> findImportProblemFixes() {
+    Iterable<ImportsQuickFixDescriptor> findImportProblemFixes() {
         return new ImportsQuickFixIterator();
     }
 


### PR DESCRIPTION
It may be possible to deprecate `VimDocument` in the future.

This commit means opened Editors will be updated whenever the file is written in Vim, and it will still be possible to edit the file within IntelliJ. We don't bother trying to *push* changes to Vim right now, since it will see the changes on disk anyway and just prompt to load as expected, but it might be possible in the future.